### PR TITLE
  File "bancodobrasil.py", line 185

### DIFF
--- a/bankscraper/bancodobrasil.py
+++ b/bankscraper/bancodobrasil.py
@@ -182,7 +182,6 @@ class BancoDoBrasil(BankScraper):
             'Janeiro': 1,
             'Fevereiro': 2,
             'Marco': 3,
-            'Março': 3,
             'Abril': 4,
             'Maio': 5,
             'Junho': 6,


### PR DESCRIPTION
python bancodobrasil.py
  File "bancodobrasil.py", line 185
SyntaxError: Non-ASCII character '\xc3' in file bancodobrasil.py on line 185, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details