### PR TITLE
 Fix BancoDoBrasilValidator class to validate branch and account number correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 env
 *.DS_Store
 *.pyc
+*~
 .python_version
 __pycache__
 ghostdriver.log

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Program to parse financial transactions from Banco do Brasil
 
 optional arguments:
   -h, --help            show this help message and exit
-  --branch BRANCH       Banco do Brasil Branch number, in the format 0000-0
-  --account ACCOUNT     Banco do Brasil Account number, in the format 0000-0
+  --branch BRANCH       Banco do Brasil Branch number, in the format 00000
+  --account ACCOUNT     Banco do Brasil Account number, in the format 000000
   --password PASSWORD   Banco do Brasil Account password
   --days DAYS           Transaction log days
   --omit-sensitive-data

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Program to parse financial transactions from Banco do Brasil
 
 optional arguments:
   -h, --help            show this help message and exit
-  --branch BRANCH       Banco do Brasil Branch number, in the format 00000
-  --account ACCOUNT     Banco do Brasil Account number, in the format 000000
+  --branch BRANCH       Banco do Brasil Branch number, maximum 5 digits (without -)
+  --account ACCOUNT     Banco do Brasil Account number, maximum 6 digits (without -)
   --password PASSWORD   Banco do Brasil Account password
   --days DAYS           Transaction log days
   --omit-sensitive-data

--- a/bankscraper/bancodobrasil.py
+++ b/bankscraper/bancodobrasil.py
@@ -200,8 +200,8 @@ class BancoDoBrasil(BankScraper):
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='Program to parse financial transactions from Banco do Brasil')
-    parser.add_argument('--branch', help='Banco do Brasil Branch number, in the format 0000-0', required=True)
-    parser.add_argument('--account', help='Banco do Brasil Account number, in the format 0000-0', required=True)
+    parser.add_argument('--branch', help='Banco do Brasil Branch number, maximum 5 digits (without -)', required=True)
+    parser.add_argument('--account', help='Banco do Brasil Account number, maximum 6 digits (without -)', required=True)
     parser.add_argument('--password', help='Banco do Brasil Account password', required=True)
     parser.add_argument('--days', help='Transaction log days', default=15, type=int)
     parser.add_argument('--omit-sensitive-data', dest='omit', action='store_true', help='Omit sensitive data, like documents, paychecks and current balance')

--- a/bankscraper/validators.py
+++ b/bankscraper/validators.py
@@ -161,6 +161,8 @@ class BankValidator(BaseValidator):
 
 class BancoDoBrasilValidator(BankValidator):
 
+    # To this validator, the two next values works as max size,
+    # because branch and account numbers don't has fixed width
     branch_size = 5
     account_size = 6
     password_size = 8
@@ -168,12 +170,21 @@ class BancoDoBrasilValidator(BankValidator):
     allowed_days = [30]
 
     fields = ['branch', 'number', 'password']
-    
+
     def branch(self, branch):
-        if len(branch) != self.branch_size:
+        return len(branch) <= self.branch_size
+
+    def account(self, account):
+
+        if '-' not in account:
+            try:
+                int(account)
+            except ValueError:
+                return False
+        else:
             return False
 
-        return True
+        return len(account) <= self.account_size
 
 
 class ItauValidator(BankValidator):

--- a/bankscraper/validators.py
+++ b/bankscraper/validators.py
@@ -162,12 +162,18 @@ class BankValidator(BaseValidator):
 class BancoDoBrasilValidator(BankValidator):
 
     branch_size = 5
-    account_size = 5
+    account_size = 6
     password_size = 8
 
     allowed_days = [30]
 
     fields = ['branch', 'number', 'password']
+    
+    def branch(self, branch):
+        if len(branch) != self.branch_size:
+            return False
+
+        return True
 
 
 class ItauValidator(BankValidator):


### PR DESCRIPTION
This pull request fix the BancoDoBrasilValidator class to validate branch and account number correctly:

- BB's account number don't fixed width 
- BB's branch has letters too (not only numbers)

For the two case the branch_size and account_size attrs works as maximum size, and account is 6 now (not 5).